### PR TITLE
fix: PUBLIC_API_BASE_URL is now controlled by AGENT_PUBLIC_DID

### DIFF
--- a/charts/values.yaml
+++ b/charts/values.yaml
@@ -34,8 +34,6 @@ vs-agent-chart:
     tlsSecret: public.{{ .Values.name }}.{{ .Values.global.domain }}-cert # TLS secret for the vs agent service
 
   extraEnv: 
-    - name: PUBLIC_API_BASE_URL
-      value: "https://{{ .Values.name }}.{{ .Values.global.domain }}"
     - name: USE_CORS
       value: "true"
 


### PR DESCRIPTION
Complement https://github.com/2060-io/hologram-generic-verifier-vs/pull/74 to force the creation of a new version with a fix commit